### PR TITLE
V2.60.8

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,11 +43,11 @@ parts:
     plugin: go
     build-snaps: [go/latest/stable]
     source: https://github.com/ledgerwatch/erigon.git
-    source-tag: v2.60.6
+    source-tag: v2.60.8
 
     override-pull: |
       craftctl default
-      craftctl set version="2.60.6-$(git rev-parse --short HEAD)"
+      craftctl set version="2.60.8-$(git rev-parse --short HEAD)"
 
     override-build: |
       # The Makefile contains bunch of compiler options. Don't even try reproduce it.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,7 +43,7 @@ parts:
     plugin: go
     build-snaps: [go/latest/stable]
     source: https://github.com/ledgerwatch/erigon.git
-    source-tag: v2.60.8
+    source-tag: 2.60.8
 
     override-pull: |
       craftctl default


### PR DESCRIPTION
Erigon modified the source-tag for the latest version without the `v`